### PR TITLE
Ensure MusicGen conditioners move to active device

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -162,7 +162,15 @@ def _move_musicgen(model, device: torch.device):
     if model is None:
         return
     _move_to_device(model, device)
-    model.device = device
+    # ``MusicGen`` exposes ``set_device`` which takes care of moving
+    # subordinate components such as the T5 text encoder.  Calling it here
+    # prevents mismatched-device errors where parts of the conditioner remain
+    # on an old GPU.
+    try:
+        model.set_device(device)
+    except AttributeError:
+        # Fallback for potential mocks or minimal stubs in tests.
+        model.device = device
 
 
 def _offload_musicgen(model):


### PR DESCRIPTION
## Summary
- ensure `_move_musicgen` calls `model.set_device` so text encoders and other conditioners move together

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ad58d0883228648cde394b546cd