### PR TITLE
Fix mastering ffmpeg sample format and default reference

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -779,8 +779,6 @@ def _apply_stereo_space(in_path: Path, out_path: Path, sr: int, width: float = 1
         f"stereotools=slev={width_s}:balance_out={pan_s}",
         "-ar",
         str(sr),
-        "-sample_fmt",
-        "s32",
         str(out_path),
     ]
     try:
@@ -795,8 +793,6 @@ def _apply_stereo_space(in_path: Path, out_path: Path, sr: int, width: float = 1
             f"stereowiden=delay=20:feedback=0.3:crossfeed={max(0.0, width_s - 1.0)}:drymix=0.8",
             "-ar",
             str(sr),
-            "-sample_fmt",
-            "s32",
             str(out_path),
         ]
         sp.run(fallback, check=True)
@@ -816,8 +812,6 @@ def _apply_bass_boost(in_path: Path, out_path: Path, sr: int, gain_db: float) ->
         f"bass=g={gain_db}",
         "-ar",
         str(sr),
-        "-sample_fmt",
-        "s32",
         str(out_path),
     ]
     sp.run(cmd, check=True)
@@ -836,7 +830,7 @@ def _master_simple(audio_input, reference_audio: str | None = None, out_trim_db:
     if reference_audio:
         ref = Path(reference_audio)
     else:
-        ref = Path.home() / "references" / "reference.wav"
+        ref = Path("/references/reference.wav")
     if not ref.exists():
         raise gr.Error(f"Reference file missing: {ref}")
     matched_path = TMP_DIR / f"mastered_simple_{uuid.uuid4().hex}.wav"

--- a/tests/test_master_simple.py
+++ b/tests/test_master_simple.py
@@ -1,0 +1,75 @@
+import types
+import sys
+from pathlib import Path
+import numpy as np
+import subprocess as sp
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Stub heavy optional dependencies so module imports without them.
+gradio_stub = types.ModuleType("gradio")
+gradio_stub.Error = type("Error", (Exception,), {})
+sys.modules.setdefault("gradio", gradio_stub)
+
+audiocraft_stub = types.ModuleType("audiocraft")
+sys.modules.setdefault("audiocraft", audiocraft_stub)
+
+data_stub = types.ModuleType("audiocraft.data")
+sys.modules.setdefault("audiocraft.data", data_stub)
+
+audio_utils_stub = types.ModuleType("audiocraft.data.audio_utils")
+audio_utils_stub.convert_audio = lambda x, *a, **k: x
+sys.modules.setdefault("audiocraft.data.audio_utils", audio_utils_stub)
+
+audio_stub = types.ModuleType("audiocraft.data.audio")
+audio_stub.audio_write = lambda *a, **k: None
+sys.modules.setdefault("audiocraft.data.audio", audio_stub)
+
+models_stub = types.ModuleType("audiocraft.models")
+class _Dummy:
+    @staticmethod
+    def get_pretrained(*a, **k):
+        return None
+models_stub.MusicGen = _Dummy
+models_stub.MultiBandDiffusion = _Dummy
+models_stub.AudioGen = _Dummy
+sys.modules.setdefault("audiocraft.models", models_stub)
+
+import musicgen_stems_continue2 as msc2
+
+
+def test_apply_stereo_space_no_sample_fmt(monkeypatch, tmp_path):
+    cmds = []
+    def fake_run(cmd, check):
+        cmds.append(cmd)
+        if len(cmds) == 1:
+            raise sp.CalledProcessError(1, cmd)
+    monkeypatch.setattr(msc2.sp, "run", fake_run)
+    inp = tmp_path / "in.wav"
+    inp.touch()
+    outp = tmp_path / "out.wav"
+    msc2._apply_stereo_space(inp, outp, sr=32000, width=1.5, pan=0.0)
+    for cmd in cmds:
+        assert "-sample_fmt" not in cmd
+    assert len(cmds) == 2
+
+
+def test_master_simple_uses_default_reference(monkeypatch, tmp_path):
+    ref_dir = Path("/references")
+    ref_dir.mkdir(exist_ok=True)
+    ref_file = ref_dir / "reference.wav"
+    ref_file.touch()
+
+    def dummy_match(target, reference, output):
+        assert reference == str(ref_file)
+        Path(output).touch()
+    monkeypatch.setattr(msc2, "_matchering_match", dummy_match)
+    monkeypatch.setattr(msc2, "_apply_bass_boost", lambda a, b, c, d: Path(b).touch())
+    monkeypatch.setattr(msc2, "_apply_stereo_space", lambda a, b, c, width, pan: Path(b).touch())
+    monkeypatch.setattr(msc2, "MATCHERING_AVAILABLE", True)
+
+    sr = 32000
+    wav = np.zeros((sr,), dtype=np.float32)
+    out = msc2._master_simple((sr, wav))
+    assert Path(out).exists()


### PR DESCRIPTION
## Summary
- drop unsupported `-sample_fmt s32` from ffmpeg mastering helpers
- default to `/references/reference.wav` when no comparison track provided
- add tests for mastering defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb93945208322ae318eb6b06725a0