### PR TITLE
Fix mastering ffmpeg sample format and default reference

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -68,11 +68,17 @@ UTILITY_DEVICE = (
     if torch.cuda.is_available() and torch.cuda.device_count() > 3
     else DIFFUSION_DEVICE
 )
+AUDIOSR_DEVICE = (
+    torch.device("cuda:1")
+    if torch.cuda.is_available() and torch.cuda.device_count() > 1
+    else UTILITY_DEVICE
+)
 
 print(
     f"[Boot] STYLE: {STYLE_DEVICE} | MEDIUM: {MEDIUM_DEVICE} | "
     f"LARGE: {LARGE_DEVICE} | AUDIOGEN: {AUDIOGEN_DEVICE} | "
-    f"DIFFUSION(MBD): {DIFFUSION_DEVICE} | UTILITY: {UTILITY_DEVICE}"
+    f"DIFFUSION(MBD): {DIFFUSION_DEVICE} | UTILITY: {UTILITY_DEVICE} | "
+    f"AUDIOSR: {AUDIOSR_DEVICE}"
 )
 
 # ---------- Constants & paths [ALTERED] ----------
@@ -776,27 +782,24 @@ def _apply_stereo_space(in_path: Path, out_path: Path, sr: int, width: float = 1
         "-i",
         str(in_path),
         "-af",
-        f"stereotools=slev={width_s}:balance_out={pan_s}",
+        f"stereotools=slev={width_s:.6f}:balance_out={pan_s:.6f}",
         "-ar",
         str(sr),
-        "-sample_fmt",
-        "s32",
         str(out_path),
     ]
     try:
         sp.run(cmd, check=True)
     except sp.CalledProcessError:
+        crossfeed = max(0.0, width_s - 1.0)
         fallback = [
             "ffmpeg",
             "-y",
             "-i",
             str(in_path),
             "-af",
-            f"stereowiden=delay=20:feedback=0.3:crossfeed={max(0.0, width_s - 1.0)}:drymix=0.8",
+            f"stereowiden=delay=20:feedback=0.3:crossfeed={crossfeed:.6f}:drymix=0.8",
             "-ar",
             str(sr),
-            "-sample_fmt",
-            "s32",
             str(out_path),
         ]
         sp.run(fallback, check=True)
@@ -816,15 +819,140 @@ def _apply_bass_boost(in_path: Path, out_path: Path, sr: int, gain_db: float) ->
         f"bass=g={gain_db}",
         "-ar",
         str(sr),
-        "-sample_fmt",
-        "s32",
         str(out_path),
     ]
     sp.run(cmd, check=True)
 
 
-def _master_simple(audio_input, reference_audio: str | None = None, out_trim_db: float = -1.0,
-                   width: float = 1.5, pan: float = 0.0, bass_boost_db: float = 0.0):
+# Bands that can be attenuated/boosted via the frequency cut UI. Each tuple is
+# (label, low_hz, high_hz, description).
+FREQ_BANDS = [
+    (
+        "Infrasound",
+        1,
+        20,
+        "Anxiety, nausea, chest pressure, hallucinations; vibrates organs/eyeballs",
+    ),
+    (
+        "Eyeball resonance",
+        16,
+        18,
+        "Visual disturbance, discomfort; matches eyeball natural frequency",
+    ),
+    (
+        "Sub-rumble conflict",
+        30,
+        80,
+        "Muddy, boomy, disorienting; overlaps room modes and sub-harmonics",
+    ),
+    (
+        "Beating tones",
+        0,
+        10,
+        "Pulsing, wobble, unsteady feeling; interference between close frequencies",
+    ),
+    (
+        "Roughness region",
+        15,
+        30,
+        "Metallic, buzzy, stressful; fast beating equals tension",
+    ),
+    (
+        "Dissonant intervals",
+        600,
+        800,
+        "Tension, unresolved, horror vibes; unstable harmonic ratios",
+    ),
+    (
+        "Midrange overload",
+        250,
+        800,
+        "Muddiness, fatigue, crowding; conflicts with human vocal range",
+    ),
+    (
+        "Harsh upper mids",
+        2500,
+        4500,
+        "Shrillness, ear pain, baby-cry level alert; peak auditory sensitivity",
+    ),
+    (
+        "Digital aliasing artifacts",
+        10000,
+        20000,
+        "Grainy, robotic, unnatural; math artifacts from poor sampling",
+    ),
+]
+
+
+def _apply_bass_narrow(in_path: Path, out_path: Path, sr: int, width: float) -> None:
+    """Reduce stereo width of low frequencies via ffmpeg."""
+    if width >= 0.999:
+        shutil.copyfile(in_path, out_path)
+        return
+    w = max(0.0, min(1.0, width))
+    mono_mix = 0.5 * (1.0 - w)
+    pan_expr = (
+        f"c0=c0*{w:.6f}+{mono_mix:.6f}*(c0+c1)|"
+        f"c1=c1*{w:.6f}+{mono_mix:.6f}*(c0+c1)"
+    )
+    filter_expr = (
+        f"asplit=2[low][high];"
+        f"[low]lowpass=f=150,pan=stereo|{pan_expr}[l];"
+        f"[high]highpass=f=150[h];"
+        f"[l][h]amix=inputs=2:dropout_transition=0"
+    )
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(in_path),
+        "-af",
+        filter_expr,
+        "-ar",
+        str(sr),
+        str(out_path),
+    ]
+    sp.run(cmd, check=True)
+
+
+def _apply_frequency_cuts(
+    in_path: Path, out_path: Path, sr: int, gains: list[float]
+) -> None:
+    """Apply per-band gain adjustments using ffmpeg's equalizer filter."""
+    filters = []
+    for gain_db, (label, low, high, _desc) in zip(gains, FREQ_BANDS):
+        if abs(gain_db) < 1e-6:
+            continue
+        center = (low + high) / 2.0
+        width = max(high - low, 1)
+        filters.append(f"equalizer=f={center}:t=h:w={width}:g={gain_db}")
+    if not filters:
+        shutil.copyfile(in_path, out_path)
+        return
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(in_path),
+        "-af",
+        ",".join(filters),
+        "-ar",
+        str(sr),
+        str(out_path),
+    ]
+    sp.run(cmd, check=True)
+
+
+def _master_simple(
+    audio_input,
+    reference_audio: str | None = None,
+    out_trim_db: float = -1.0,
+    width: float = 1.5,
+    pan: float = 0.0,
+    bass_boost_db: float = 0.0,
+    bass_width: float = 0.0,
+    freq_gains: list[float] | None = None,
+):
     if not MATCHERING_AVAILABLE:
         raise gr.Error("Matchering not installed. `pip install matchering`")
     try:
@@ -836,7 +964,7 @@ def _master_simple(audio_input, reference_audio: str | None = None, out_trim_db:
     if reference_audio:
         ref = Path(reference_audio)
     else:
-        ref = Path.home() / "references" / "reference.wav"
+        ref = Path("/references/reference.wav")
     if not ref.exists():
         raise gr.Error(f"Reference file missing: {ref}")
     matched_path = TMP_DIR / f"mastered_simple_{uuid.uuid4().hex}.wav"
@@ -845,16 +973,25 @@ def _master_simple(audio_input, reference_audio: str | None = None, out_trim_db:
     _apply_bass_boost(matched_path, bass_path, sr, bass_boost_db)
     widened_path = TMP_DIR / f"mastered_simple_wide_{uuid.uuid4().hex}.wav"
     _apply_stereo_space(bass_path, widened_path, sr, width=width, pan=pan)
-    return str(widened_path)
+    narrowed_path = TMP_DIR / f"mastered_simple_narrow_{uuid.uuid4().hex}.wav"
+    _apply_bass_narrow(widened_path, narrowed_path, sr, bass_width)
+    final_path = TMP_DIR / f"mastered_simple_final_{uuid.uuid4().hex}.wav"
+    _apply_frequency_cuts(
+        narrowed_path,
+        final_path,
+        sr,
+        freq_gains or [0.0] * len(FREQ_BANDS),
+    )
+    return str(final_path)
 
 
 def audiosr_load_model():
-    """Load and cache the AudioSR model on the utility device."""
+    """Load and cache the AudioSR model on the dedicated AudioSR device."""
     global AUDIOSR_MODEL
     if AUDIOSR_MODEL is None:
         if not AUDIOSR_AVAILABLE:
             raise gr.Error("AudioSR not installed. Add the 'versatile_audio_super_resolution' directory.")
-        AUDIOSR_MODEL = audiosr_build_model(device=str(UTILITY_DEVICE))
+        AUDIOSR_MODEL = audiosr_build_model(device=str(AUDIOSR_DEVICE))
     return AUDIOSR_MODEL
 
 
@@ -880,12 +1017,48 @@ def _audiosr_process(audio_input):
     return str(out_path)
 
 
-def master_track(audio_input, reference_audio: str | None, out_trim_db: float = -1.0,
-                 width: float = 1.5, pan: float = 0.0, bass_boost_db: float = 0.0,
-                 method: str = "Matchering"):
+def master_track(
+    audio_input,
+    reference_audio: str | None,
+    out_trim_db: float = -1.0,
+    width: float = 1.5,
+    pan: float = 0.0,
+    bass_boost_db: float = 0.0,
+    bass_width: float = 0.0,
+    infrasound_db: float = 0.0,
+    eyeball_db: float = 0.0,
+    sub_rumble_db: float = 0.0,
+    beating_db: float = 0.0,
+    roughness_db: float = 0.0,
+    dissonant_db: float = 0.0,
+    midrange_db: float = 0.0,
+    harsh_db: float = 0.0,
+    alias_db: float = 0.0,
+    method: str = "Matchering",
+):
     if method == "AudioSR":
         return _audiosr_process(audio_input)
-    return _master_simple(audio_input, reference_audio, out_trim_db, width, pan, bass_boost_db)
+    gains = [
+        infrasound_db,
+        eyeball_db,
+        sub_rumble_db,
+        beating_db,
+        roughness_db,
+        dissonant_db,
+        midrange_db,
+        harsh_db,
+        alias_db,
+    ]
+    return _master_simple(
+        audio_input,
+        reference_audio,
+        out_trim_db,
+        width,
+        pan,
+        bass_boost_db,
+        bass_width,
+        gains,
+    )
 
 # ============================================================================
 # UI (tabs, all Enqueue) [ALTERED]
@@ -1023,12 +1196,37 @@ def ui_full(launch_kwargs):
             width_master = gr.Slider(0.5, 3.0, value=1.5, step=0.1, label="Stereo Width")
             pan_master = gr.Slider(-1.0, 1.0, value=0.0, step=0.1, label="Stereo Pan")
             bass_master = gr.Slider(0.0, 12.0, value=0.0, step=0.5, label="Bass Boost (dB)")
+            bass_width = gr.Slider(0.0, 1.0, value=0.0, step=0.1, label="Bass Width", info="0=mono")
+            freq_sliders = []
+            with gr.Accordion("Frequency Cuts", open=False):
+                for label, low, high, desc in FREQ_BANDS:
+                    rng = f"{low}-{high} Hz" if low != high else f"{low} Hz"
+                    freq_sliders.append(
+                        gr.Slider(
+                            -12.0,
+                            12.0,
+                            value=0.0,
+                            step=0.5,
+                            label=f"{label} ({rng})",
+                            info=desc,
+                        )
+                    )
             master_method = gr.Radio(["Matchering", "AudioSR"], value="Matchering", label="Method")
             out_master = gr.Audio(label="Output", type="filepath")
             btn_master = gr.Button("Enqueue", variant="primary")
             btn_master.click(
                 master_track,
-                inputs=[audio_in3, ref_master, out_trim_master, width_master, pan_master, bass_master, master_method],
+                inputs=[
+                    audio_in3,
+                    ref_master,
+                    out_trim_master,
+                    width_master,
+                    pan_master,
+                    bass_master,
+                    bass_width,
+                    *freq_sliders,
+                    master_method,
+                ],
                 outputs=out_master,
                 queue=True,
             )

--- a/tests/test_master_simple.py
+++ b/tests/test_master_simple.py
@@ -1,0 +1,145 @@
+import types
+import sys
+from pathlib import Path
+import numpy as np
+import subprocess as sp
+import pytest
+
+try:
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - minimal torch stub
+    class _DummyTensor:
+        def __init__(self, arr=None):
+            self.arr = arr
+
+        def float(self):
+            return self
+
+        def t(self):
+            return self
+
+    nn_stub = types.ModuleType("torch.nn")
+    nn_stub.Module = object
+    nn_stub.Parameter = lambda *a, **k: None
+    nn_stub.functional = types.ModuleType("torch.nn.functional")
+    torch = types.SimpleNamespace(
+        Tensor=object,
+        from_numpy=lambda x: _DummyTensor(x),
+        nn=nn_stub,
+        cuda=types.SimpleNamespace(is_available=lambda: False, device_count=lambda: 0),
+        device=lambda *a, **k: types.SimpleNamespace(type=(a[0] if a else "cpu")),
+    )
+    sys.modules.setdefault("torch", torch)
+    sys.modules.setdefault("torch.nn", nn_stub)
+    sys.modules.setdefault("torch.nn.functional", nn_stub.functional)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Stub heavy optional dependencies so module imports without them.
+gradio_stub = types.ModuleType("gradio")
+gradio_stub.Error = type("Error", (Exception,), {})
+sys.modules.setdefault("gradio", gradio_stub)
+
+audiocraft_stub = types.ModuleType("audiocraft")
+sys.modules.setdefault("audiocraft", audiocraft_stub)
+
+data_stub = types.ModuleType("audiocraft.data")
+sys.modules.setdefault("audiocraft.data", data_stub)
+
+audio_utils_stub = types.ModuleType("audiocraft.data.audio_utils")
+audio_utils_stub.convert_audio = lambda x, *a, **k: x
+sys.modules.setdefault("audiocraft.data.audio_utils", audio_utils_stub)
+
+audio_stub = types.ModuleType("audiocraft.data.audio")
+audio_stub.audio_write = lambda *a, **k: None
+sys.modules.setdefault("audiocraft.data.audio", audio_stub)
+
+models_stub = types.ModuleType("audiocraft.models")
+class _Dummy:
+    @staticmethod
+    def get_pretrained(*a, **k):
+        return None
+models_stub.MusicGen = _Dummy
+models_stub.MultiBandDiffusion = _Dummy
+models_stub.AudioGen = _Dummy
+sys.modules.setdefault("audiocraft.models", models_stub)
+
+import musicgen_stems_continue2 as msc2
+
+
+def test_apply_stereo_space_no_sample_fmt(monkeypatch, tmp_path):
+    cmds = []
+    def fake_run(cmd, check):
+        cmds.append(cmd)
+        if len(cmds) == 1:
+            raise sp.CalledProcessError(1, cmd)
+    monkeypatch.setattr(msc2.sp, "run", fake_run)
+    inp = tmp_path / "in.wav"
+    inp.touch()
+    outp = tmp_path / "out.wav"
+    msc2._apply_stereo_space(inp, outp, sr=32000, width=1.5, pan=0.0)
+    for cmd in cmds:
+        assert "-sample_fmt" not in cmd
+    assert len(cmds) == 2
+
+
+def test_apply_bass_narrow_builds_filter(monkeypatch, tmp_path):
+    cmds = []
+    monkeypatch.setattr(msc2.sp, "run", lambda cmd, check: cmds.append(cmd))
+    inp = tmp_path / "in.wav"
+    inp.touch()
+    outp = tmp_path / "out.wav"
+    msc2._apply_bass_narrow(inp, outp, sr=32000, width=0.0)
+    af_arg = cmds[0][cmds[0].index("-af") + 1]
+    assert "lowpass" in af_arg
+    assert "(1-" not in af_arg
+    assert "c0=c0*0.000000+0.500000*(c0+c1)" in af_arg
+
+
+def test_apply_frequency_cuts_uses_equalizer(monkeypatch, tmp_path):
+    cmds = []
+    monkeypatch.setattr(msc2.sp, "run", lambda cmd, check: cmds.append(cmd))
+    inp = tmp_path / "in.wav"
+    inp.touch()
+    outp = tmp_path / "out.wav"
+    gains = [0.0] * len(msc2.FREQ_BANDS)
+    gains[0] = -3.0
+    msc2._apply_frequency_cuts(inp, outp, sr=32000, gains=gains)
+    assert "equalizer" in cmds[0][cmds[0].index("-af") + 1]
+
+
+def test_master_simple_uses_default_reference(monkeypatch, tmp_path):
+    ref_dir = Path("/references")
+    ref_dir.mkdir(exist_ok=True)
+    ref_file = ref_dir / "reference.wav"
+    ref_file.touch()
+
+    def dummy_match(target, reference, output):
+        assert reference == str(ref_file)
+        Path(output).touch()
+    monkeypatch.setattr(msc2, "_matchering_match", dummy_match)
+    monkeypatch.setattr(msc2, "_apply_bass_boost", lambda a, b, c, d: Path(b).touch())
+    monkeypatch.setattr(msc2, "_apply_stereo_space", lambda a, b, c, width, pan: Path(b).touch())
+    monkeypatch.setattr(msc2, "_apply_bass_narrow", lambda a, b, c, w: Path(b).touch())
+    monkeypatch.setattr(msc2, "_apply_frequency_cuts", lambda a, b, c, g: Path(b).touch())
+    monkeypatch.setattr(msc2, "MATCHERING_AVAILABLE", True)
+
+    sr = 32000
+    wav = np.zeros((sr,), dtype=np.float32)
+    out = msc2._master_simple((sr, wav))
+    assert Path(out).exists()
+
+
+def test_audiosr_loads_on_configured_device(monkeypatch):
+    called = {}
+
+    def fake_build_model(device):  # captures device string
+        called["device"] = device
+        return object()
+
+    monkeypatch.setattr(msc2, "AUDIOSR_AVAILABLE", True)
+    monkeypatch.setattr(msc2, "audiosr_build_model", fake_build_model, raising=False)
+    msc2.AUDIOSR_MODEL = None
+
+    msc2.audiosr_load_model()
+    assert called["device"] == str(msc2.AUDIOSR_DEVICE)

--- a/tests/test_move_to_device.py
+++ b/tests/test_move_to_device.py
@@ -1,7 +1,23 @@
 import types
 import sys
+import types
 
-import torch
+try:
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - stub torch when unavailable
+    nn_stub = types.ModuleType("torch.nn")
+    nn_stub.Module = object
+    nn_stub.Parameter = lambda *a, **k: None
+    torch = types.SimpleNamespace(
+        nn=nn_stub,
+        Tensor=object,
+        randn=lambda *a, **k: 0,
+        device=lambda *a, **k: types.SimpleNamespace(type=(a[0] if a else "cpu")),
+        cuda=types.SimpleNamespace(is_available=lambda: False, device_count=lambda: 0),
+    )
+    sys.modules.setdefault("torch", torch)
+    sys.modules.setdefault("torch.nn", nn_stub)
+    sys.modules.setdefault("torch.nn.functional", types.ModuleType("torch.nn.functional"))
 import pytest
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- format ffmpeg width/pan values to fixed precision and stabilize fallback crossfeed
- precompute bass narrow pan mix to avoid ffmpeg syntax errors
- expand tests with torch module stubs and stricter bass-narrow assertions
- route AudioSR to use cuda1 instead of the utility device

## Testing
- `pip install numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb93945208322ae318eb6b06725a0