### PR TITLE
Fix pan filter syntax in bass narrowing

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -900,12 +900,13 @@ def _apply_bass_narrow(in_path: Path, out_path: Path, sr: int, width: float) -> 
         return
     w = max(0.0, min(1.0, width))
     if w <= 1e-6:
-        pan_expr = "c0=0.5*(c0+c1)|c1=0.5*(c0+c1)"
+        pan_expr = "c0=0.5*c0+0.5*c1|c1=0.5*c0+0.5*c1"
     else:
         mono_mix = 0.5 * (1.0 - w)
+        base = w + mono_mix
         pan_expr = (
-            f"c0=c0*{w:.6f}+{mono_mix:.6f}*(c0+c1)|"
-            f"c1=c1*{w:.6f}+{mono_mix:.6f}*(c0+c1)"
+            f"c0={base:.6f}*c0+{mono_mix:.6f}*c1|"
+            f"c1={base:.6f}*c1+{mono_mix:.6f}*c0"
         )
     filter_expr = (
         f"asplit=2[low][high];"

--- a/tests/test_master_simple.py
+++ b/tests/test_master_simple.py
@@ -91,7 +91,7 @@ def test_apply_bass_narrow_builds_filter(monkeypatch, tmp_path):
     af_arg = cmds[0][cmds[0].index("-af") + 1]
     assert "lowpass" in af_arg
     assert "(1-" not in af_arg
-    assert "c0=0.5*(c0+c1)|c1=0.5*(c0+c1)" in af_arg
+    assert "c0=0.5*c0+0.5*c1|c1=0.5*c0+0.5*c1" in af_arg
 
 
 def test_apply_frequency_cuts_uses_equalizer(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- correct ffmpeg pan expression in `_apply_bass_narrow` to mix channels without parentheses
- update tests for new filter expression

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce0851364832282daf4353951c3f1