### PR TITLE
Fix pan filter syntax in bass narrowing

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import subprocess as sp
 import sys
 import shutil
+import numpy as np
 
 import torch
 import torch.nn.functional as F
@@ -38,6 +39,10 @@ try:
 except ImportError:
     mg = None  # ensure symbol exists for type checkers and wrappers
     MATCHERING_AVAILABLE = False
+
+# numpy 1.24+ removed aliases like ``np.float`` that older libs still use
+if not hasattr(np, "float"):
+    np.float = float  # type: ignore[attr-defined]
 
 try:
     sys.path.append(str(Path(__file__).resolve().parent / "versatile_audio_super_resolution"))
@@ -900,12 +905,13 @@ def _apply_bass_narrow(in_path: Path, out_path: Path, sr: int, width: float) -> 
         return
     w = max(0.0, min(1.0, width))
     if w <= 1e-6:
-        pan_expr = "c0=0.5*(c0+c1)|c1=0.5*(c0+c1)"
+        pan_expr = "c0=0.5*c0+0.5*c1|c1=0.5*c0+0.5*c1"
     else:
         mono_mix = 0.5 * (1.0 - w)
+        base = w + mono_mix
         pan_expr = (
-            f"c0=c0*{w:.6f}+{mono_mix:.6f}*(c0+c1)|"
-            f"c1=c1*{w:.6f}+{mono_mix:.6f}*(c0+c1)"
+            f"c0={base:.6f}*c0+{mono_mix:.6f}*c1|"
+            f"c1={base:.6f}*c1+{mono_mix:.6f}*c0"
         )
     filter_expr = (
         f"asplit=2[low][high];"

--- a/tests/test_master_simple.py
+++ b/tests/test_master_simple.py
@@ -91,7 +91,7 @@ def test_apply_bass_narrow_builds_filter(monkeypatch, tmp_path):
     af_arg = cmds[0][cmds[0].index("-af") + 1]
     assert "lowpass" in af_arg
     assert "(1-" not in af_arg
-    assert "c0=0.5*(c0+c1)|c1=0.5*(c0+c1)" in af_arg
+    assert "c0=0.5*c0+0.5*c1|c1=0.5*c0+0.5*c1" in af_arg
 
 
 def test_apply_frequency_cuts_uses_equalizer(monkeypatch, tmp_path):

--- a/tests/test_numpy_float_alias.py
+++ b/tests/test_numpy_float_alias.py
@@ -1,0 +1,9 @@
+import numpy as np
+import importlib
+
+# Importing the module should ensure np.float is available
+import musicgen_stems_continue2  # noqa: F401
+
+def test_numpy_float_alias_defined():
+    assert hasattr(np, "float")
+    assert np.float is float


### PR DESCRIPTION
## Summary
- correct ffmpeg pan expression in `_apply_bass_narrow` to mix channels without parentheses
- update tests for new filter expression
- add numpy import and `np.float` compatibility shim for AudioSR
- add regression test asserting `np.float` alias exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce0851364832282daf4353951c3f1