### PR TITLE
Add RVC vocal conversion helper

### DIFF
--- a/tests/test_rvc.py
+++ b/tests/test_rvc.py
@@ -1,0 +1,11 @@
+import pytest
+import musicgen_stems_continue2 as msc2
+
+
+def test_rvc_raises_when_unavailable(tmp_path):
+    assert not msc2.RVC_AVAILABLE
+    vocal = tmp_path / "vocal.wav"
+    model = tmp_path / "model.pth"
+    out = tmp_path / "out.wav"
+    with pytest.raises(RuntimeError):
+        msc2.rvc_convert_vocals(vocal, model, out)


### PR DESCRIPTION
## Summary
- add optional RVC dependency and helper function for voice conversion with pitch, index ratio and filter radius controls
- document pre/post-processing and inference tuning guidelines for RVC usage
- test: ensure RVC helper raises when library is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd760269948322bff4c1a4ef67b9a0