### PR TITLE
style: refine neon green theme and banner alignment

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -270,9 +270,16 @@ button:hover, .gr-button:hover {{
     background: var(--color-accent);
     color: #000;
 }}
+mark, .highlight {{
+    background: var(--color-accent);
+    color: #000;
+}}
 #top-banner {{
     display: flex;
     justify-content: flex-start;
+    align-items: flex-start;
+    margin-left: 0;
+    text-align: left;
 }}
 """
 


### PR DESCRIPTION
## Summary
- extend highlight styling so marked text uses neon green accent
- ensure top banner sticks to the left with explicit alignment rules

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08046146c832294df4b137e629d5a