### PR TITLE
Include custom output directory in Gradio allowed paths

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -3106,7 +3106,13 @@ if __name__ == "__main__":
 
     warnings.filterwarnings("ignore", category=UserWarning)
     logging.basicConfig(level=logging.INFO)
-    ui_full({"server_name": args.listen, "server_port": args.port})
+    ui_full(
+        {
+            "server_name": args.listen,
+            "server_port": args.port,
+            "allowed_paths": [str(TMP_DIR)],
+        }
+    )
 
 
 


### PR DESCRIPTION
## Summary
- permit Gradio to serve files from the persistent music directory by passing it in `allowed_paths`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c08c78dcb08322925200f6a4b6e9e0