### PR TITLE
use repo output dir

### DIFF
--- a/musicgen_stems_continue2.py
+++ b/musicgen_stems_continue2.py
@@ -188,7 +188,11 @@ print(
 # ---------- Constants & paths [ALTERED] ----------
 TARGET_SR = 32000
 TARGET_AC = 1
-TMP_DIR = Path("/home/archway/music/n-Track")  # writable, persistent
+# Use a temporary directory within the repository so that generated files
+# reside in a location automatically permitted by Gradio. This avoids
+# InvalidPathError when returning files outside the working or system temp
+# directories and makes the folder safe to expose via ``allowed_paths``.
+TMP_DIR = (Path(__file__).resolve().parent / "outputs")
 TMP_DIR.mkdir(parents=True, exist_ok=True)
 
 # Persisted user settings (EQ, UI preferences, etc.) are stored as JSON within


### PR DESCRIPTION
## Summary
- ensure output directory lives within repo so Gradio can cache generated files
- clarify comment about exposing the outputs directory via `allowed_paths`

## Testing
- `pip install numpy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c09c69392c8322b6e556126b530ba7