### PR TITLE
Tie deck fades to playback control hold duration

### DIFF
--- a/harmoniq/src/App.tsx
+++ b/harmoniq/src/App.tsx
@@ -673,7 +673,7 @@ export default function App() {
     }
   };
 
-  const handleTogglePlayback = async (deckId: DeckId) => {
+  const handleTogglePlayback = async (deckId: DeckId, holdSeconds?: number | null) => {
     if (!audioBridge) return;
     const deck = decks.find((item) => item.id === deckId);
     if (!deck) return;
@@ -681,11 +681,13 @@ export default function App() {
       await handleRetryPlayback(deckId);
       return;
     }
+    const fadeDurationSeconds =
+      typeof holdSeconds === "number" && Number.isFinite(holdSeconds) ? holdSeconds : undefined;
     try {
       if (deck.isPlaying) {
-        await audioBridge.stopDeck(deckId);
+        await audioBridge.stopDeck(deckId, { fadeDurationSeconds });
       } else {
-        await audioBridge.playDeck(deckId);
+        await audioBridge.playDeck(deckId, { fadeDurationSeconds });
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- capture play/stop button hold duration in DeckMatrix and forward it through App to the audio bridge
- allow HarmoniqAudioBridge.playDeck/stopDeck to accept custom fade durations and ramp gains with that timing
- add a regression test confirming custom fade durations propagate to the gain ramps

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f993da1b188320a035c54b2dcfa822